### PR TITLE
Bug Fix: Client Header Component - wrong date picker month

### DIFF
--- a/client/src/components/header/TransactionModel.js
+++ b/client/src/components/header/TransactionModel.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Button,
@@ -24,12 +24,13 @@ import LoadingButton from '@mui/lab/LoadingButton';
 function AddTransaction() {
   // Get store values
   const store = Store.useContainer();
+  const month = store.month;
 
   // states for modal and form
   const [open, setOpen] = useState(false);
   const [type, setType] = useState(Type.INCOME);
   const [category, setCategory] = useState('');
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(month);
   const [adding, setAdding] = useState(false);
 
   const handleOpen = () => setOpen(true);
@@ -39,8 +40,12 @@ function AddTransaction() {
     setOpen(false);
     setType('I');
     setCategory('');
-    setSelectedDate(new Date());
   };
+
+  // display datepicker month according to selected month
+  useEffect(() => {
+    setSelectedDate(month);
+  }, [month]);
 
   // Add transaction API call
   const addTransaction = (e) => {


### PR DESCRIPTION
### Issue

- When opening the add transaction model, the date picker month does not match the selected month.
- It causes the transactions to be added with wrong dates to the wrong month's budget.

### Changes Made
I added a `useEffect` hook to switch the date picker month when the selected month changes.

### Screenshots

The selected month is December 2022, but the date picker opens the current month.

![Screenshot](https://github.com/Nimi-NimiX/pet-project-chinthaka/assets/47731399/09f791e2-e1d3-40eb-a805-3dcd2f02962a)
